### PR TITLE
feat: update tasks models and endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -845,7 +845,6 @@ func (c *ArtifactsMMO) GetTasksRewards(page int, size int) (*[]models.TaskReward
 func (c *ArtifactsMMO) GetTaskReward(code string) (*models.TaskRewardFull, error) {
 	var ret models.TaskRewardFull
 
-	//res, err := api.NewRequest(c.Config, &ret, "GET", fmt.Sprintf("%s/tasks/rewards/%s", apiUrl, code), nil).Run()
 	res, err := api.NewRequest(c.Config).SetMethod("GET").SetURL(fmt.Sprintf("/tasks/rewards/%s", code)).SetResultStruct(&ret).Run()
 	if err != nil {
 		return nil, err

--- a/models/responses.go
+++ b/models/responses.go
@@ -89,7 +89,7 @@ type TaskCancelled struct {
 
 type TaskRewardData struct {
 	Cooldown  Cooldown   `json:"cooldown"`
-	Reward    TaskReward `json:"reward"`
+	Rewards   TaskReward `json:"rewards"`
 	Character Character  `json:"character"`
 }
 
@@ -104,19 +104,20 @@ type BaseAchievement struct {
 }
 
 type TaskFull struct {
-	Code        string   `json:"code"`
-	Level       int      `json:"level"`
-	Type        TaskType `json:"type"`
-	MinQuantity int      `json:"min_quantity"`
-	MaxQuantity int      `json:"max_quantity"`
-	Skill       string   `json:"skill"`
+	Code        string     `json:"code"`
+	Level       int        `json:"level"`
+	Type        TaskType   `json:"type"`
+	MinQuantity int        `json:"min_quantity"`
+	MaxQuantity int        `json:"max_quantity"`
+	Skill       string     `json:"skill"`
+	Rewards     TaskReward `json:"rewards"`
 }
 
 type TaskRewardFull struct {
-	Code        string  `json:"code"`
-	MinQuantity int     `json:"min_quantity"`
-	MaxQuantity int     `json:"max_quantity"`
-	Odds        float32 `json:"odds"`
+	Code        string `json:"code"`
+	Rate        int    `json:"rate"`
+	MinQuantity int    `json:"min_quantity"`
+	MaxQuantity int    `json:"max_quantity"`
 }
 
 type GEItems struct {

--- a/models/task.go
+++ b/models/task.go
@@ -8,14 +8,15 @@ const (
 )
 
 type Task struct {
-	Code  string   `json:"code"`
-	Type  TaskType `json:"type"`
-	Total int      `json:"total"`
+	Code    string     `json:"code"`
+	Type    TaskType   `json:"type"`
+	Total   int        `json:"total"`
+	Rewards TaskReward `json:"rewards"`
 }
 
 type TaskReward struct {
-	Code     string `json:"code"`
-	Quantity int    `json:"quantity"`
+	Items []SimpleItem `json:"items"`
+	Gold  int          `json:"gold"`
 }
 
 type TaskTrade SimpleItem


### PR DESCRIPTION
added the `code` param to the `getTaskRewards` endpoint

and also added/renamed `rewards` anywhere applicable