### PR TITLE
Fix bank deposit and withdrawal

### DIFF
--- a/client.go
+++ b/client.go
@@ -318,11 +318,11 @@ func (c *ArtifactsMMO) DepositBankGold(quantity int) (*models.BankGoldTransactio
 	return &ret, nil
 }
 
-func (c *ArtifactsMMO) WithdrawBank(code string, quantity int) (*models.BankItemTransaction, error) {
+func (c *ArtifactsMMO) WithdrawBank(items []models.SimpleItem) (*models.BankItemTransaction, error) {
 	var ret models.BankItemTransaction
 
-	body := models.SimpleItem{Code: code, Quantity: quantity}
-	res, err := api.NewRequest(c.Config).SetMethod("POST").SetURL(fmt.Sprintf("/my/%s/action/bank/withdraw", c.Config.GetUsername())).SetResultStruct(&ret).SetBody(body).Run()
+	body := items
+	res, err := api.NewRequest(c.Config).SetMethod("POST").SetURL(fmt.Sprintf("/my/%s/action/bank/withdraw/item", c.Config.GetUsername())).SetResultStruct(&ret).SetBody(body).Run()
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -273,12 +273,12 @@ func (c *ArtifactsMMO) Recycling(code string, quantity int) (*models.Recycling, 
 	return &ret, nil
 }
 
-func (c *ArtifactsMMO) DepositBank(code string, quantity int) (*models.BankItemTransaction, error) {
+func (c *ArtifactsMMO) DepositBank(items []models.SimpleItem) (*models.BankItemTransaction, error) {
 	var ret models.BankItemTransaction
 
-	body := models.SimpleItem{Code: code, Quantity: quantity}
+	body := items
 
-	res, err := api.NewRequest(c.Config).SetMethod("POST").SetURL(fmt.Sprintf("/my/%s/action/bank/deposit", c.Config.GetUsername())).SetResultStruct(&ret).SetBody(body).Run()
+	res, err := api.NewRequest(c.Config).SetMethod("POST").SetURL(fmt.Sprintf("/my/%s/action/bank/deposit/item", c.Config.GetUsername())).SetResultStruct(&ret).SetBody(body).Run()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on new logic introduced in the API for the [Bank Deposit](https://api.artifactsmmo.com/docs/#/operations/action_deposit_bank_item_my__name__action_bank_deposit_item_post) and [Bank Withdrawal](https://api.artifactsmmo.com/docs/#/operations/action_withdraw_bank_item_my__name__action_bank_withdraw_item_post), converted these two methods to instead use arrays of models.SimpleItem instead of singular items being deposited/withdrawn at a time.